### PR TITLE
Get more granular debug data before uninstall

### DIFF
--- a/content.js
+++ b/content.js
@@ -29,7 +29,9 @@ darkModeListener(darkModePreference);
 const isInputOrTextarea = (currEle) => ["input", "textarea"].includes(currEle.tagName.toLowerCase());
 document.body.onpaste = event => {
     let currEle = document.activeElement;
-    if (forcePasterSettings.isPasteEnabled && isInputOrTextarea(currEle)) {
+    if (forcePasterSettings.isPasteEnabled) {
+        chrome.runtime.sendMessage({ type: "onpastestart", on: currEle.tagName.toLowerCase() })
+        if (!isInputOrTextarea(currEle)) return;
         let currVal = currEle.value;
         let finalVal = "";
 
@@ -47,7 +49,7 @@ document.body.onpaste = event => {
         currEle.value = "";
         currEle.value = finalVal;
         setCaretPositionToEndOfPastedText(currEle, caretPos);
-        chrome.runtime.sendMessage({ type: "onpaste" }, response => {
+        chrome.runtime.sendMessage({ type: "onpastecomplete" }, response => {
             if (response.totalPastes > 10) {
                 // TODO: show a dismissible box at the top right of the page
                 // asking users to rate the extension on the webstore if they liked using it

--- a/service_worker.js
+++ b/service_worker.js
@@ -38,7 +38,7 @@ chrome.action.onClicked.addListener(() => {
 });
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    const { type } = request;
+    const { type, on } = request;
     if (type === "themechange") {
         const icon_paths = {
             "16": `icons/${request.mode}/icon16.png`,
@@ -47,7 +47,15 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             "128": `icons/${request.mode}/icon128.png`
         };
         chrome.action.setIcon({path: icon_paths});
-    } else if (type === "onpaste") {
+    } else if (type === "onpastestart") {
+        chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+            saveAndApplyExtensionDetails({
+                pasteStart: forcePasterSettings.pasteCount + 1,
+                lastDomain: (new URL(tabs[0].url)).origin,
+                lastTag: on,
+            });
+        })
+    } else if (type === "onpastecomplete") {
         saveAndApplyExtensionDetails({
             pasteCount: forcePasterSettings.pasteCount + 1,
         });


### PR DESCRIPTION
Some users are reporting in the uninstall survey that it doesn't work on govt website. But so far no one has given specific examples of these websites

Adding the following data to uninstall form:
- How many times paste was attempted while enabled
- How many times it succeeded
- Last URL the extension was attempted at
- Last HTML tag the extension was attempted at.