### PR TITLE
Added functionality for iframe

### DIFF
--- a/content.js
+++ b/content.js
@@ -76,13 +76,15 @@ function setCaretPositionToEndOfPastedText(elem, caretPos) {
     }
 }
 
-document.body.onkeydown = async event => {
-    if (forcePasterSettings.isPasteEnabled
-        && window.location.hostname == "www.pw.live"
-        && event.target.tagName.toLowerCase() === 'input'
-    ) {
-        if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
-            document.execCommand('paste')
-        }
-    }
-};
+// This doesnt do anything so I commented it out, the problem was that element is on an iframe
+
+// document.body.onkeydown = async event => {
+//     if (forcePasterSettings.isPasteEnabled
+//         && window.location.hostname == "www.pw.live"
+//         && event.target.tagName.toLowerCase() === 'input'
+//     ) {
+//         if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
+//             document.execCommand('paste')
+//         }
+//     }
+// };

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Force Paster",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "This extension allows you to paste text into input fields in websites that have disabled pasting.",
   "icons": {
     "16": "icons/light/icon16.png",
@@ -17,7 +17,9 @@
       "matches": [
         "http://*/*",
         "https://*/*"
-      ]
+      ],
+      "all_frames": true,
+      "run_at": "document_end"
     }
   ],
   "background": {


### PR DESCRIPTION
I added some simple changes so that its workable for iframe and run the scripts within the fame using `"run_at": "document_end"` this seemingly fixed all other issues related and future proof it for other unsupported sites.

Breakdown of what I did:
- added support for iframes to the manifest `"all_frames": true, "run_at": "document_end"`
- commented out unnecessary code
- incremented the version 