### PR TITLE
Fix Brave shortcut settings detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Force Paster is a browser extension that lets you paste text into any input fiel
 - **Right-click context menu** — toggle, open the dashboard, manage shortcuts, rate the extension, or report a bug directly from the toolbar icon
 - **Dashboard** — a tabbed settings page (Settings / What's new / More); open it via the context menu or `chrome://extensions` → Details → Extension options
 - **Dark & light icons** — the toolbar icon automatically follows your system theme
-- **Cross-browser** — works on Chrome, Firefox (121+), and Edge
+- **Cross-browser** — works on Chrome, Brave, Firefox (121+), and Edge
 
 ---
 
@@ -24,7 +24,7 @@ Force Paster is a browser extension that lets you paste text into any input fiel
 
 | Browser | Link |
 |---------|------|
-| Chrome / Edge | [Chrome Web Store](https://vashis.ht/rd/forcepaster?from=github-readme) |
+| Chrome / Brave / Edge | [Chrome Web Store](https://vashis.ht/rd/forcepaster?from=github-readme) |
 | Firefox | [Firefox Add-ons](https://vashis.ht/rd/forcepaster?from=github-readme) |
 
 ### Load unpacked (development)
@@ -33,7 +33,7 @@ Force Paster is a browser extension that lets you paste text into any input fiel
    ```bash
    git clone https://github.com/prvashisht/force-paster.git
    ```
-2. **Chrome / Edge** — navigate to `chrome://extensions/`, enable **Developer mode**, click **Load unpacked**, and select the cloned folder.
+2. **Chrome / Brave / Edge** — navigate to `chrome://extensions/`, enable **Developer mode**, click **Load unpacked**, and select the cloned folder.
 3. **Firefox** — navigate to `about:debugging#/runtime/this-firefox`, click **Load Temporary Add-on**, and select `manifest.json` inside the cloned folder.
 
 ---
@@ -69,7 +69,7 @@ options.html / options.js
 
 ### Browser compatibility
 
-All Chrome/Firefox API differences are centralised in `webext.js`. The service worker and options page use `webext.*` throughout; `content.js` and `analytics.js` use the `chrome` namespace, which Firefox MV3 also exposes in those contexts.
+All Chromium/Firefox API differences are centralised in `webext.js`. The service worker and options page use `webext.*` throughout; `content.js` and `analytics.js` use the `chrome` namespace, which Firefox MV3 also exposes in those contexts.
 
 ---
 
@@ -78,7 +78,7 @@ All Chrome/Firefox API differences are centralised in `webext.js`. The service w
 | File | Description |
 |------|-------------|
 | `manifest.json` | Extension manifest (MV3) — permissions, icons, content script registration, keyboard command, options page |
-| `webext.js` | Browser adapter — detects Chrome/Edge vs Firefox at runtime, re-exports APIs under a unified `webext` object, and adds helpers like `openShortcutsPage()` and `action.getUserSettings()` |
+| `webext.js` | Browser adapter — detects Chromium browsers vs Firefox at runtime, re-exports APIs under a unified `webext` object, and adds helpers like `openShortcutsPage()` and `action.getUserSettings()` |
 | `content.js` | Content script injected into every page — intercepts paste events and forwards theme-change messages to the service worker |
 | `service_worker.js` | Background service worker — manages toggle state, badge, context menu, options page, and all analytics calls |
 | `options.html` | Dashboard markup — tabbed UI with Settings, What's new, and More panels |
@@ -119,7 +119,7 @@ Events are sent anonymously via a Cloud Functions proxy. The following events ar
 
 ### Keyboard shortcut remap
 
-- **Chrome / Edge** — `chrome://extensions/shortcuts`
+- **Chrome / Brave / Edge** — `chrome://extensions/shortcuts`
 - **Firefox** — `about:addons` → Extensions → Force Paster → Manage
 
 ### Releasing a new version
@@ -127,7 +127,7 @@ Events are sent anonymously via a Cloud Functions proxy. The following events ar
 1. Bump `"version"` in `manifest.json`.
 2. Update `"version"` and `"notes"` in `release-notes.json` to match — the build will **fail** if they differ.
 3. Merge to `main`. The `release.yml` workflow triggers automatically, builds both zips, creates a GitHub release with auto-generated notes, and attaches the zips as assets. This in turn triggers `store-deploy.yml`, which publishes automatically to the Chrome Web Store and Firefox Add-ons.
-4. **Edge** — upload `force-paster-chrome-v*.zip` from the GitHub release manually at [Microsoft Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/overview). The Chrome zip is Edge-compatible (same Chromium base; Firefox-only manifest fields are stripped by the build script).
+4. **Edge** — upload `force-paster-chrome-v*.zip` from the GitHub release manually at [Microsoft Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/overview). The Chrome zip is compatible with Chromium browsers such as Brave and Edge; Firefox-only manifest fields are stripped by the build script.
 
 > **Checklist every release:**
 > - [ ] `manifest.json` version bumped

--- a/build.sh
+++ b/build.sh
@@ -62,10 +62,10 @@ build() {
 
 echo "Building Force Paster v$VERSION ..."
 
-# Chrome/Edge: drop Firefox-only fields (gecko block + background.scripts)
+# Chromium browsers: drop Firefox-only fields (gecko block + background.scripts)
 build "chrome" "delete m.browser_specific_settings; delete m.background.scripts;"
 
-# Firefox: drop the Chrome/Edge-only service_worker key (Firefox uses background.scripts)
+# Firefox: drop the Chromium-only service_worker key (Firefox uses background.scripts)
 build "firefox" "delete m.background.service_worker;"
 
 echo "Done."

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Force Paster",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "This extension allows you to paste text into input fields in websites that have disabled pasting.",
   "icons": {
     "16": "icons/light/icon16.png",

--- a/options.js
+++ b/options.js
@@ -1,6 +1,8 @@
 // Inline adapter: options pages run in a window (not a worker), so we skip the ES module.
-// Firefox MV3 supports both `browser` and `chrome` in extension pages; prefer `browser`.
-const webext = (typeof browser !== 'undefined' && browser.runtime) ? browser : chrome;
+// Chromium browsers may expose `browser`; runtime.getBrowserInfo is Firefox-specific.
+const isFirefoxBrowser = typeof browser !== 'undefined'
+    && typeof browser.runtime?.getBrowserInfo === 'function';
+const webext = isFirefoxBrowser ? browser : chrome;
 
 const manifest = webext.runtime.getManifest();
 document.getElementById('version').textContent = `v${manifest.version}`;
@@ -68,8 +70,7 @@ async function loadShortcut() {
     }
 
     // Show browser-appropriate remap hint
-    const isFirefox = typeof browser !== 'undefined';
-    if (isFirefox) {
+    if (isFirefoxBrowser) {
         hintEl.innerHTML = 'To remap, go to <code>about:addons</code> → Extensions → Force Paster → Manage.';
     } else {
         hintEl.innerHTML = 'To remap, open <code>chrome://extensions/shortcuts</code> in your address bar.';
@@ -80,7 +81,6 @@ async function loadShortcut() {
 
 const pinCard = document.getElementById('pin-card');
 const pinDesc = document.getElementById('pin-card-desc');
-const isFirefoxBrowser = typeof browser !== 'undefined';
 
 function setPinCardVisible(isOnToolbar) {
     if (isOnToolbar) {

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.5.3",
+  "version": "2.5.4",
   "notes": [
-    "Rich text paste in rich editors (e.g. Notion): formatting is preserved by re-dispatching the clipboard to the page, with sensible fallbacks when a site blocks paste"
+    "Fix keyboard shortcut management links in Brave and other Chromium browsers that expose the WebExtensions `browser` namespace"
   ]
 }

--- a/webext.js
+++ b/webext.js
@@ -7,12 +7,14 @@
  *   webext.openShortcutsPage()
  *
  * Detection:
- *   - Firefox MV3 exposes a `browser` global with a Promise-based API.
- *   - Chrome and Edge expose `chrome`. Edge also mirrors under `chrome`.
+ *   - Firefox exposes runtime.getBrowserInfo().
+ *   - Chromium browsers may expose both `chrome` and `browser`, so the
+ *     presence of `browser` alone is not a Firefox signal.
  *   - We prefer `browser` on Firefox so we get native Promises everywhere.
  */
 
-const _isFirefox = typeof browser !== 'undefined' && !!browser.runtime?.getManifest;
+const _isFirefox = typeof browser !== 'undefined'
+    && typeof browser.runtime?.getBrowserInfo === 'function';
 const _api = _isFirefox ? browser : chrome;
 
 export const isFirefox = _isFirefox;

--- a/webext.js
+++ b/webext.js
@@ -29,7 +29,7 @@ async function openShortcutsPage() {
         // Firefox does not support chrome:// URLs; about:addons is the equivalent.
         await _api.tabs.create({ url: 'about:addons' });
     } else {
-        // Chrome and Edge
+        // Chromium browsers
         await _api.tabs.create({ url: 'chrome://extensions/shortcuts' });
     }
 }


### PR DESCRIPTION
## Summary
- Detect Firefox via `runtime.getBrowserInfo` instead of the presence of the `browser` namespace, so Brave and other Chromium browsers open `chrome://extensions/shortcuts`.
- Update options-page hints and README wording to cover Brave/Chromium behavior.
- Bump the extension release metadata to `2.5.4` with matching release notes.

## Testing
- `./build.sh`
- `git diff --check`