### PR TITLE
[codex] Migrate analytics to generic GA proxy

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,93 @@
+# Privacy Policy
+
+Effective date: June 2, 2026
+
+## TL;DR
+
+**Force Paster does not collect your pasted text, clipboard contents, page
+contents, personal information, account information, payment information, or
+full browsing history.** **It does not sell personal data or use analytics for
+ad targeting.**
+
+The extension stores only the settings and operating state it needs to work,
+and may send limited operational analytics events to help maintain the
+extension. Paste analytics may include the website domain and element type
+where a paste completed, but **not the pasted text, page contents, or full
+URL.**
+
+Force Paster is a browser extension that lets you paste text into input fields,
+text areas, and supported editable page regions even when a website tries to
+block paste events.
+
+## Personal Data
+
+**Force Paster does not ask for your name, email address, account information,
+or payment information.** **It does not collect or send pasted text, rich
+clipboard data, page contents, or full browsing history.**
+
+When Force Paster is enabled and you paste into a supported field, the content
+script reads the clipboard data from that paste event only so it can insert the
+data into the focused field. For contenteditable editors, the extension may
+replay the paste event inside the page so the site's own editor can handle rich
+clipboard formats. **Clipboard contents are not stored by the extension or sent
+to us.**
+
+## Local Settings
+
+The extension uses browser extension storage to save settings and operating
+state, including whether Force Paster is enabled, toggle count, paste count,
+rating prompt state, dashboard state, the last handled field type, and the last
+handled website domain. This data is stored in your browser's extension storage
+and is used to keep the extension working consistently.
+
+The extension may also store non-personal installation, client, and session
+identifiers locally to support operational analytics. Removing the extension
+clears extension storage according to your browser's behavior.
+
+## Limited Operational Analytics
+
+The extension may send limited analytics events to understand extension health
+and usage. These events can include actions such as install, update, enable or
+disable, paste completed, context menu click, options page open, options page
+click, and rating prompt response.
+
+Event data may include the extension version, browser or platform metadata,
+locale, time zone, generated client/session identifiers, enabled state, event
+source, menu item, rating choice, paste count, paste count bucket, the focused
+element type, and the website domain where a paste completed.
+
+**Pasted text, rich clipboard contents, page contents, and full URLs are not
+sent in analytics events.** Analytics data is used to maintain and improve the
+extension, **not to sell personal data or target advertising.**
+
+Analytics events are sent through a Cloud Functions proxy before being processed
+by Google Analytics. Analytics failures do not block extension behavior.
+
+## Uninstall Page
+
+If you uninstall the extension, your browser may open the Force Paster uninstall
+page. That URL may include operational debug data such as extension version,
+browser/platform metadata, locale, time zone, install or update date, enabled
+state, usage counts, rating prompt state, last handled field type, and last
+handled website domain. This information is used to diagnose extension issues
+and improve the extension.
+
+## Browser And Website Policies
+
+When you use Force Paster, your browser and the websites you visit still process
+your browsing and paste interactions according to their own privacy policies.
+For example, the website you paste into receives the pasted content as part of
+the normal paste workflow, and your browser handles extension storage, tab
+navigation, and any account-level behavior it provides.
+
+## Contact And Issues
+
+To report a privacy concern, bug, or support request, open an issue in the Force
+Paster repository:
+
+https://github.com/prvashisht/force-paster/issues
+
+## Changes
+
+This policy may be updated when the extension's behavior changes. Updates will
+be published in this repository.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Force Paster is a browser extension that lets you paste text into any input field or text area — even on sites that have deliberately blocked pasting. One click enables it; one click turns it back off.
 
+[Privacy Policy](PRIVACY_POLICY.md)
+
 ---
 
 ## Features
@@ -85,16 +87,18 @@ All Chromium/Firefox API differences are centralised in `webext.js`. The service
 | `options.js` | Dashboard logic — reads/writes storage, reflects live state changes, loads release notes, sends analytics via service worker messages |
 | `release-notes.json` | Current version's release notes — bundled with the extension and displayed in the What's new tab |
 | `analytics.js` | Analytics helper — proxies GA4 events through a Cloud Functions endpoint with client-ID and session management |
+| `PRIVACY_POLICY.md` | Privacy policy — documents local storage, clipboard handling, analytics, and uninstall-page data |
 
 ---
 
 ## Analytics events
 
-Events are sent anonymously via a Cloud Functions proxy. The following events are tracked:
+Events are sent anonymously via the generic Cloud Functions GA proxy, identified as Force Paster with `X-Extension-App: forcepaster`. Existing install token, client ID, and session storage keys are retained for continuity. Analytics failures are logged and do not block extension behavior.
 
 | Event | When | Key params |
 |-------|------|------------|
-| `extension_installed` | Install or update | `reason`, platform info, locale |
+| `fp_extension_installed` | First install | `reason`, platform info, locale |
+| `fp_extension_updated` | Extension update | `reason`, platform info, locale |
 | `fp_toggle` | Enable/disable toggled | `enabled`, `source` (`action_icon` / `context_menu` / `options_page`) |
 | `fp_paste` | Paste completed | `tag` (element type), `domain` |
 | `fp_menu_click` | Context menu item clicked (non-toggle) | `item` (`shortcuts` / `options` / `rate` / `bug`) |

--- a/analytics.js
+++ b/analytics.js
@@ -1,5 +1,5 @@
 // --- GA Proxy config ---
-const PROXY_BASE_URL = "https://asia-south1-extensions-analytics-prod.cloudfunctions.net/forcepaster-ga-proxy";
+const PROXY_BASE_URL = "https://asia-south1-extensions-analytics-prod.cloudfunctions.net/extensions-ga-proxy";
 export const TOKEN_STORAGE_KEY = "forcepaster_install_token";
 export const CLIENT_ID_STORAGE_KEY = "forcepaster_ga_client_id";
 const SESSION_STORAGE_KEY = "forcepaster_ga_session";
@@ -48,6 +48,7 @@ async function registerInstallToken() {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "X-Extension-App": "forcepaster",
       "X-Extension-Id": chrome.runtime.id
     },
     body: JSON.stringify({})
@@ -109,6 +110,7 @@ export async function sendProxyEvent(eventName, params = {}, opts = {}) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${bearerToken}`,
+        "X-Extension-App": "forcepaster",
         "X-Extension-Id": chrome.runtime.id
       },
       body: JSON.stringify(payload)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Force Paster",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "This extension allows you to paste text into input fields in websites that have disabled pasting.",
   "icons": {
     "16": "icons/light/icon16.png",

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.5.4",
+  "version": "2.5.5",
   "notes": [
-    "Fix keyboard shortcut management links in Brave and other Chromium browsers that expose the WebExtensions `browser` namespace"
+    "Migrate analytics events to the generic GA proxy with separate install and update lifecycle events"
   ]
 }

--- a/service_worker.js
+++ b/service_worker.js
@@ -280,10 +280,13 @@ webext.runtime.onInstalled.addListener(async installInfo => {
     // Read existing settings first so paste_count is available for the event.
     const { forcepaster: existingSettings } = await webext.storage.local.get('forcepaster');
     const existingPasteCount = existingSettings?.pasteCount ?? 0;
+    const lifecycleEventName = installInfo.reason === "install"
+        ? "fp_extension_installed"
+        : "fp_extension_updated";
 
     try {
         await sendProxyEvent(
-            "extension_installed",
+            lifecycleEventName,
             {
                 reason: installInfo.reason,
                 ...withPasteCountAnalytics(existingPasteCount),


### PR DESCRIPTION
## Summary

- Migrate Force Paster analytics to the generic GA proxy and send `X-Extension-App: forcepaster` on register and collect calls.
- Split lifecycle analytics into `fp_extension_installed` and `fp_extension_updated` while keeping existing runtime event names unchanged.
- Add a Force Paster privacy policy, link it from the README, and document analytics/storage behavior.
- Bump the extension release metadata to `2.5.5`.

## Validation

- `./build.sh`
- Built `dist/force-paster-chrome-v2.5.5.zip` and `dist/force-paster-firefox-v2.5.5.zip`.