### PR TITLE
Fix image paste into contenteditable editors (ChatGPT, etc.)

### DIFF
--- a/content.js
+++ b/content.js
@@ -96,8 +96,9 @@ function pasteIntoInputField(el, pastedText) {
 // contenteditable  (Gmail, Notion, Slack-style editors)
 //
 // Strategy: re-dispatch a synthetic ClipboardEvent carrying the original
-// clipboard payload (all MIME types) so the site's own editor can handle
-// the paste natively — preserving rich formatting in apps like Notion.
+// clipboard payload (all MIME types, plus any files) so the site's own
+// editor can handle the paste natively — preserving rich formatting in
+// apps like Notion and image attachments in apps like ChatGPT.
 //
 // If the site blocked the paste (no DOM change), fall back to insertHTML
 // (rich) or insertText (plain) via execCommand / Selection API.
@@ -107,7 +108,13 @@ function pasteIntoContentEditable(el, pastedText, originalClipboard) {
 
     const dt = new DataTransfer();
     for (const type of originalClipboard.types) {
+        // "Files" isn't real string data — getData() always returns '' for it.
+        // Actual File objects are cloned separately below via items.add().
+        if (type === 'Files') continue;
         dt.setData(type, originalClipboard.getData(type));
+    }
+    for (const file of originalClipboard.files) {
+        dt.items.add(file);
     }
 
     const syntheticEvent = new ClipboardEvent('paste', {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Force Paster",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "This extension allows you to paste text into input fields in websites that have disabled pasting.",
   "icons": {
     "16": "icons/light/icon16.png",

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.5.5",
+  "version": "2.5.6",
   "notes": [
-    "Migrate analytics events to the generic GA proxy with separate install and update lifecycle events"
+    "Image paste in rich editors (e.g. ChatGPT): clipboard files are now included when re-dispatching paste to the page"
   ]
 }


### PR DESCRIPTION
## Summary
- Fixes #39. `pasteIntoContentEditable` rebuilt its synthetic `ClipboardEvent`'s `DataTransfer` by looping over `originalClipboard.types` and cloning each via `setData(type, getData(type))`. Image (`File`-kind) clipboard entries can't be read via `getData()` — it always returns an empty string for them — so pasted image bytes were silently dropped before the site's own paste handler (e.g. ChatGPT's) ever saw them, and nothing got pasted.
- Now clones actual `File` objects from `originalClipboard.files` into the synthetic `DataTransfer` via `dt.items.add(file)`, so image pastes (screenshots, copied images, etc.) reach the site's editor intact.
- Scoped narrowly to the image-paste bug only; the separate large-text/ChatGPT-attachment issue (#32) is intentionally untouched here and will be addressed independently.

## Test plan
- [x] With the extension enabled, copy a screenshot/image and paste into a ChatGPT prompt — confirm it attaches/renders as it would with the extension disabled.
- [x] Paste an image into another contenteditable-based rich text editor (e.g. Gmail compose, Notion) — confirm no regression.
- [x] Re-verify existing rich-text paste behavior (e.g. pasting formatted text into Notion) still works as before.