### PR TITLE
Retire exact paste_count from analytics

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Force Paster",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "This extension allows you to paste text into input fields in websites that have disabled pasting.",
   "icons": {
     "16": "icons/light/icon16.png",

--- a/release-notes.json
+++ b/release-notes.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.5.6",
+  "version": "2.5.7",
   "notes": [
-    "Image paste in rich editors (e.g. ChatGPT): clipboard files are now included when re-dispatching paste to the page"
+    "Internal: analytics now report a paste-count range instead of the exact number"
   ]
 }

--- a/service_worker.js
+++ b/service_worker.js
@@ -34,8 +34,9 @@ function getPasteCountBucket(pasteCount) {
 }
 
 function withPasteCountAnalytics(pasteCount) {
+    // Only emit the low-cardinality bucket. The exact count exploded GA event
+    // cardinality, so it was retired.
     return {
-        paste_count: pasteCount,
         paste_count_bucket: getPasteCountBucket(pasteCount),
     };
 }
@@ -277,7 +278,7 @@ webext.runtime.onInstalled.addListener(async installInfo => {
     if (installDate) debugData.installDate = installDate;
     if (updateDate) debugData.updateDate = updateDate;
 
-    // Read existing settings first so paste_count is available for the event.
+    // Read existing settings first so the paste bucket is available for the event.
     const { forcepaster: existingSettings } = await webext.storage.local.get('forcepaster');
     const existingPasteCount = existingSettings?.pasteCount ?? 0;
     const lifecycleEventName = installInfo.reason === "install"


### PR DESCRIPTION
## Summary
- Stop sending exact `paste_count` on analytics events (it was exploding GA cardinality)
- Keep only the existing `paste_count_bucket`
- Bump to 2.5.7

## Test plan
- [x] Sideload build and confirm events still fire with `paste_count_bucket` and without `paste_count`
- [ ] After merge, confirm Release + Store Deploy run for 2.5.7
- [ ] Point any GA reports still using `paste_count` at `paste_count_bucket`