### PR TITLE
docs: clarify local development (Chrome load-unpacked warning + local build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Force Paster is a browser extension that lets you paste text into any input fiel
 2. **Chrome / Brave / Edge** — navigate to `chrome://extensions/`, enable **Developer mode**, click **Load unpacked**, and select the cloned folder.
 3. **Firefox** — navigate to `about:debugging#/runtime/this-firefox`, click **Load Temporary Add-on**, and select `manifest.json` inside the cloned folder.
 
+> **Note (Chrome):** loading the folder unpacked shows a harmless warning — `'background.scripts' requires manifest version of 2 or lower.` This is expected. `manifest.json` is shared across browsers (Firefox uses `background.scripts`, Chrome uses `background.service_worker`), and `build.sh` strips the key that doesn't apply to each target when packaging. The extension still loads and works normally.
+
 ---
 
 ## How it works
@@ -120,6 +122,10 @@ Events are sent anonymously via the generic Cloud Functions GA proxy, identified
 2. In Chrome, go to `chrome://extensions/` and click the **reload** icon on the Force Paster card to pick up changes.
 3. In Firefox, go to `about:debugging#/runtime/this-firefox` and click **Reload** next to Force Paster.
 4. Test on a site that blocks pasting (e.g. many banking or exam portals).
+
+### Building the packaged zips
+
+You don't need this to develop, but to produce the distributable zips locally, run `./build.sh`. It writes `dist/force-paster-chrome-v*.zip` and `dist/force-paster-firefox-v*.zip`, and requires Node.js and `zip`. The build fails if the `manifest.json` and `release-notes.json` versions don't match.
 
 ### Keyboard shortcut remap
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small docs-only clarification for contributors setting up locally. No source code changes.

- Note that loading the folder unpacked in Chrome shows a harmless `'background.scripts' requires manifest version of 2 or lower.` warning, and explain why (`manifest.json` is shared across browsers; `build.sh` strips the non-applicable key per target). This is a common point of confusion when loading unpacked.
- Add a short "Building the packaged zips" note pointing at `./build.sh` (needs Node.js + `zip`, and requires `manifest.json`/`release-notes.json` versions to match).

## Verification

- `./build.sh` runs cleanly and produces the Chrome and Firefox zips under `dist/`.
- Loaded the folder unpacked in Chrome via `chrome://extensions` → Load unpacked; confirmed the documented warning appears and the extension still loads and works. On a page with a paste-blocked input, `Ctrl+V` is blocked while the extension is off and pastes successfully once toggled on.

[force_paster_paste_blocked_then_enabled_demo.mp4](https://cursor.com/agents/bc-6c5186ba-4448-49cf-ad20-f9dd2bcc570b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforce_paster_paste_blocked_then_enabled_demo.mp4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c5186ba-4448-49cf-ad20-f9dd2bcc570b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c5186ba-4448-49cf-ad20-f9dd2bcc570b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

